### PR TITLE
fix documentation of ten_crop

### DIFF
--- a/chainercv/transforms/image/ten_crop.py
+++ b/chainercv/transforms/image/ten_crop.py
@@ -9,6 +9,7 @@ def ten_crop(img, output_shape):
     crops and horizontal flips of them.
 
     The crops are ordered in this order.
+
     * center crop
     * top-left crop
     * bottom-left crop


### PR DESCRIPTION
![screenshot from 2017-03-14 14 49 04](https://cloud.githubusercontent.com/assets/2062128/23887474/6a3adcd6-08c5-11e7-8597-edb18d156913.png)


# after

![screenshot from 2017-03-14 14 47 32](https://cloud.githubusercontent.com/assets/2062128/23887476/6f9e7318-08c5-11e7-9f81-2651f49121c8.png)
