### PR TITLE
Delete chw_to_pil_image_tuple

### DIFF
--- a/chainercv/extensions/detection/detection_vis_report.py
+++ b/chainercv/extensions/detection/detection_vis_report.py
@@ -6,7 +6,7 @@ import chainer
 from chainer.utils import type_check
 
 from chainercv.tasks import vis_bbox
-from chainercv.transforms import chw_to_pil_image_tuple
+from chainercv.transforms import chw_to_pil_image
 from chainercv.utils.extension_utils import check_type
 from chainercv.utils.extension_utils import forward
 
@@ -25,6 +25,10 @@ def _check_available():
                       'so nothing will be plotted at this time. '
                       'Please install matplotlib to plot figures.\n\n'
                       '  $ pip install matplotlib\n')
+
+
+def _detection_vis_transform(xs):
+    return chw_to_pil_image(xs[0]), xs[1], xs[2]
 
 
 class DetectionVisReport(chainer.training.extension.Extension):
@@ -143,7 +147,7 @@ class DetectionVisReport(chainer.training.extension.Extension):
 
     def __init__(self, indices, dataset, target,
                  filename_base='detection', predict_func=None,
-                 vis_transform=chw_to_pil_image_tuple):
+                 vis_transform=_detection_vis_transform):
         _check_available()
 
         if not isinstance(indices, collections.Iterable):

--- a/chainercv/extensions/semantic_segmentation/semantic_segmentation_vis_report.py
+++ b/chainercv/extensions/semantic_segmentation/semantic_segmentation_vis_report.py
@@ -7,7 +7,7 @@ import warnings
 import chainer
 from chainer.utils import type_check
 
-from chainercv.transforms import chw_to_pil_image_tuple
+from chainercv.transforms import chw_to_pil_image
 from chainercv.utils import check_type
 from chainercv.utils import forward
 
@@ -26,10 +26,6 @@ def _check_available():
                       'so nothing will be plotted at this time. '
                       'Please install matplotlib to plot figures.\n\n'
                       '  $ pip install matplotlib\n')
-
-
-def chw_to_pil_image_tuple_img_label(xs):
-    return chw_to_pil_image_tuple(xs, indices=[0, 1])
 
 
 class SemanticSegmentationVisReport(chainer.training.extension.Extension):
@@ -148,7 +144,7 @@ class SemanticSegmentationVisReport(chainer.training.extension.Extension):
 
     def __init__(self, indices, dataset, target, n_class,
                  filename_base='semantic_seg', predict_func=None,
-                 vis_transform=chw_to_pil_image_tuple_img_label):
+                 vis_transform=chw_to_pil_image):
         _check_available()
 
         if not isinstance(indices, collections.Iterable):

--- a/chainercv/transforms/__init__.py
+++ b/chainercv/transforms/__init__.py
@@ -1,7 +1,6 @@
 from chainercv.transforms.bbox.flip_bbox import flip_bbox  # NOQA
 from chainercv.transforms.bbox.resize_bbox import resize_bbox  # NOQA
 from chainercv.transforms.image.chw_to_pil_image import chw_to_pil_image  # NOQA
-from chainercv.transforms.image.chw_to_pil_image import chw_to_pil_image_tuple  # NOQA
 from chainercv.transforms.image.flip import flip  # NOQA
 from chainercv.transforms.image.pad import pad  # NOQA
 from chainercv.transforms.image.pca_lighting import pca_lighting  # NOQA

--- a/chainercv/transforms/image/chw_to_pil_image.py
+++ b/chainercv/transforms/image/chw_to_pil_image.py
@@ -1,11 +1,23 @@
 import numpy as np
+import six
+
+
+def _chw_to_pil_image(img, reverse_color_channel):
+    img = img.transpose(1, 2, 0)
+    if reverse_color_channel:
+        img = img[:, :, ::-1]
+    return img.astype(np.uint8)
 
 
 def chw_to_pil_image(img, reverse_color_channel=True):
     """Transforms a CHW array into uint8 HWC array.
 
+    This function transforms one or multiple CHW arrays into HWC format
+    whose types :obj:`dtype==numpy.uint8`.
+
     Args:
-        img (~numpy.ndarray): an array in CHW format.
+        img (~numpy.ndarray, or tuple of arrays): an array or tuple of arrays
+            which are in CHW format.
         bgr_to_rgb (bool): If true, the array's color channel is
             reversed.
 
@@ -17,35 +29,10 @@ def chw_to_pil_image(img, reverse_color_channel=True):
         ~numpy.ndarray: a uint8 image array
 
     """
-    img = img.transpose(1, 2, 0)
-    if reverse_color_channel:
-        img = img[:, :, ::-1]
-    return img.astype(np.uint8)
+    if not isinstance(img, tuple):
+        return _chw_to_pil_image(img, reverse_color_channel)
 
-
-def chw_to_pil_image_tuple(imgs, indices=[0], reverse_color_channel=True):
-    """Transforms CHW arrays into uint8 HWC arrays.
-
-    This function transforms selected arrays in a tuple into HWC arrays
-    which are :obj:`dtype==numpy.uint8`.
-
-    Args:
-        imgs (tuple of numpy.ndarray): Tuple of numpy.ndarrays which are not
-            limited to image arrays.
-        indices (list of ints): The integers in :obj:`indices` point to
-            arrays in :obj:`imgs` which will be converted.
-        bgr_to_rgb (bool): If true, the array's color channel is
-            reversed.
-
-            .. code:: python
-
-                img = img[:, :, ::-1]
-
-    Returns:
-        tuple of numpy.ndarray
-
-    """
-    imgs = list(imgs)
-    for i in indices:
+    imgs = list(img)
+    for i in six.moves.range(len(imgs)):
         imgs[i] = chw_to_pil_image(imgs[i], reverse_color_channel)
     return tuple(imgs)

--- a/chainercv/transforms/image/chw_to_pil_image.py
+++ b/chainercv/transforms/image/chw_to_pil_image.py
@@ -10,7 +10,7 @@ def _chw_to_pil_image(img, reverse_color_channel):
 
 
 def chw_to_pil_image(img, reverse_color_channel=True):
-    """Transforms a CHW array into uint8 HWC array.
+    """Transforms one or multiple CHW arrays into uint8 HWC arrays.
 
     This function transforms one or multiple CHW arrays into HWC format
     whose types :obj:`dtype==numpy.uint8`.
@@ -26,7 +26,8 @@ def chw_to_pil_image(img, reverse_color_channel=True):
                 img = img[:, :, ::-1]
 
     Returns:
-        ~numpy.ndarray: a uint8 image array
+        an array or tuple of arrays: These arrays are in HWC format and have
+            uint8 as data type.
 
     """
     if not isinstance(img, tuple):

--- a/docs/source/reference/transforms.rst
+++ b/docs/source/reference/transforms.rst
@@ -11,10 +11,6 @@ chw_to_pil_image
 ~~~~~~~~~~~~~~~~
 .. autofunction:: chw_to_pil_image
 
-chw_to_pil_image_tuple
-~~~~~~~~~~~~~~~~~~~~~~
-.. autofunction:: chw_to_pil_image_tuple
-
 flip
 ~~~~
 .. autofunction:: flip

--- a/examples/semantic_segmentation/fcn/train_fcn.py
+++ b/examples/semantic_segmentation/fcn/train_fcn.py
@@ -138,8 +138,7 @@ def main():
             [103.939, 116.779, 123.68], np.float32)[:, None, None]
         img, label = in_data
         img += vgg_subtract_bgr
-        img, label = transforms.chw_to_pil_image_tuple(
-            (img, label), indices=[0, 1])
+        img, label = transforms.chw_to_pil_image((img, label))
         return img, label
 
     trainer.extend(

--- a/tests/transforms_tests/image_tests/test_chw_to_pil_image.py
+++ b/tests/transforms_tests/image_tests/test_chw_to_pil_image.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from chainer import testing
 from chainercv.transforms import chw_to_pil_image
-from chainercv.transforms import chw_to_pil_image_tuple
 
 
 class TestCHWToPILImage(unittest.TestCase):
@@ -26,18 +25,13 @@ class TestCHWToPILImage(unittest.TestCase):
         y = y_uint8.astype(np.float32)
         imgs = (img, y)
 
-        img_obtained, y_obtained = chw_to_pil_image_tuple(
-            imgs, indices=[0], reverse_color_channel=False)
-        np.testing.assert_equal(img_obtained.transpose(2, 0, 1), img_uint8)
-        np.testing.assert_equal(y_obtained, y)
-
-        img_obtained, y_obtained = chw_to_pil_image_tuple(
-            imgs, indices=[0, 1], reverse_color_channel=False)
+        img_obtained, y_obtained = chw_to_pil_image(
+            imgs, reverse_color_channel=False)
         np.testing.assert_equal(img_obtained.transpose(2, 0, 1), img_uint8)
         np.testing.assert_equal(y_obtained.transpose(2, 0, 1), y)
 
-        img_obtained, y_obtained = chw_to_pil_image_tuple(
-            imgs, indices=[0, 1], reverse_color_channel=True)
+        img_obtained, y_obtained = chw_to_pil_image(
+            imgs, reverse_color_channel=True)
         np.testing.assert_equal(
             img_obtained.transpose(2, 0, 1), img_uint8[::-1, :, :])
         np.testing.assert_equal(


### PR DESCRIPTION
`chw_to_pil_image_tuple` has several problems.

+ name is too long and hard to remember
+ User needs to set value of `indices` when they want to do CHW->PIL for all arrays in a tuple
+ Confusing together with `chw_to_pil_image`

I propose to delete this function and merge functionality to `chw_to_pil_image`. I dropped support for `indices`, which seems to be unnecessary.