### PR TITLE
Add tilde before numpy.ndarray

### DIFF
--- a/chainercv/tasks/detection/vis_bbox.py
+++ b/chainercv/tasks/detection/vis_bbox.py
@@ -15,13 +15,13 @@ def vis_bbox(img, bbox, label=None, label_names=None, ax=None):
         >>> plot.show()
 
     Args:
-        img (numpy.ndarray): array of shape :math:`(height, width, 3)`.
+        img (~numpy.ndarray): array of shape :math:`(height, width, 3)`.
             This is in RGB format.
-        bbox (numpy.ndarray): an array of shape :math:`(R, 5)`, where :math:`R`
+        bbox (~numpy.ndarray): an array of shape :math:`(R, 5)`, where :math:`R`
             is the number of bounding boxes in the image. Elements are
             organized
             by :obj:`(x_min, y_min, x_max, y_max)` in the second axis.
-        label (numpy.ndarray): an integer array of shape :math:`(R,)`.
+        label (~numpy.ndarray): an integer array of shape :math:`(R,)`.
             The values correspond to id for label names stored in
             :obj:`label_names`. This is optional.
         label_names (iterable of strings): name of labels ordered according

--- a/chainercv/tasks/detection/vis_bbox.py
+++ b/chainercv/tasks/detection/vis_bbox.py
@@ -17,9 +17,9 @@ def vis_bbox(img, bbox, label=None, label_names=None, ax=None):
     Args:
         img (~numpy.ndarray): array of shape :math:`(height, width, 3)`.
             This is in RGB format.
-        bbox (~numpy.ndarray): an array of shape :math:`(R, 5)`, where :math:`R`
-            is the number of bounding boxes in the image. Elements are
-            organized
+        bbox (~numpy.ndarray): an array of shape :math:`(R, 5)`, where
+            :math:`R` is the number of bounding boxes in the image. Elements
+            are organized
             by :obj:`(x_min, y_min, x_max, y_max)` in the second axis.
         label (~numpy.ndarray): an integer array of shape :math:`(R,)`.
             The values correspond to id for label names stored in

--- a/chainercv/tasks/semantic_segmentation/eval_semantic_segmentation.py
+++ b/chainercv/tasks/semantic_segmentation/eval_semantic_segmentation.py
@@ -24,9 +24,9 @@ def label_accuracy_score(label_true, label_pred, n_class):
       - fwavacc
 
     Args:
-        label_true (numpy.ndarray): a integer 2D image of classes. A pixel
+        label_true (~numpy.ndarray): a integer 2D image of classes. A pixel
             with value "-1" will be ignored during evaluation.
-        label_pred (numpy.ndarray): a integer 2D image.
+        label_pred (~numpy.ndarray): a integer 2D image.
         n_class (int):  number of classes
     """
     hist = _fast_hist(label_true.flatten(), label_pred.flatten(), n_class)

--- a/chainercv/transforms/image/flip.py
+++ b/chainercv/transforms/image/flip.py
@@ -2,7 +2,7 @@ def flip(img, horizontal=False, vertical=False, copy=False):
     """Flip an image in vertical or horizontal direction as specified.
 
     Args:
-        img (numpy.ndarray): An array that gets flipped. This is in CHW format.
+        img (~numpy.ndarray): An array that gets flipped. This is in CHW format.
         horizontal (bool): flip in horizontal direction
         vertical (bool): flip in vertical direction
         copy (bool): If False, a view of :obj:`img` will be returned.

--- a/chainercv/transforms/image/flip.py
+++ b/chainercv/transforms/image/flip.py
@@ -2,8 +2,8 @@ def flip(img, horizontal=False, vertical=False, copy=False):
     """Flip an image in vertical or horizontal direction as specified.
 
     Args:
-        img (~numpy.ndarray): An array that gets flipped. This is in CHW format.
-        horizontal (bool): flip in horizontal direction
+        img (~numpy.ndarray): An array that gets flipped. This is in CHW
+        format. horizontal (bool): flip in horizontal direction
         vertical (bool): flip in vertical direction
         copy (bool): If False, a view of :obj:`img` will be returned.
 

--- a/chainercv/transforms/image/pad.py
+++ b/chainercv/transforms/image/pad.py
@@ -25,7 +25,7 @@ def _get_pad_slices(img, max_size):
     """Get slices needed for padding.
 
     Args:
-        img (numpy.ndarray): this image is in format CHW.
+        img (~numpy.ndarray): this image is in format CHW.
         max_size (tuple of two ints): (max_H, max_W).
     """
     _, H, W = img.shape

--- a/chainercv/transforms/image/pca_lighting.py
+++ b/chainercv/transforms/image/pca_lighting.py
@@ -14,15 +14,15 @@ def pca_lighting(img, sigma, eigen_value=None, eigen_vector=None):
     NIPS 2012.
 
     Args:
-        img (numpy.ndarray): An image array to be augmented. This is in
+        img (~numpy.ndarray): An image array to be augmented. This is in
             CHW format.
         sigma (float): Standard deviation of the Gaussian. In the original
             paper, this value is 10% of the range of intensity
             (25.5 if the range is [0, 255]).
-        eigen_value: (numpy.ndarray): An array of eigen values. The shape
+        eigen_value: (~numpy.ndarray): An array of eigen values. The shape
             have to be (3,). If it is not specified, the values computed from
             ImageNet are used.
-        eigen_vector: (numpy.ndarray): An array of eigen vectors. The shape
+        eigen_vector: (~numpy.ndarray): An array of eigen vectors. The shape
             have to be (3, 3). If it is not specified, the vectors computed
             from ImageNet are used.
 

--- a/chainercv/transforms/image/random_crop.py
+++ b/chainercv/transforms/image/random_crop.py
@@ -9,7 +9,7 @@ def random_crop(img, output_shape, return_slices=False, copy=False):
     output will all be in shape :obj:`output_shape`.
 
     Args:
-        img (numpy.ndarray): An image array to be cropped. This is in
+        img (~numpy.ndarray): An image array to be cropped. This is in
             CHW format.
         output_shape (tuple): the size of output image after cropping.
             This value is :math:`(heihgt, width)`.

--- a/chainercv/transforms/image/random_flip.py
+++ b/chainercv/transforms/image/random_flip.py
@@ -6,7 +6,7 @@ def random_flip(img, random_h=False, random_v=False,
     """Randomly flip an image in vertical or horizontal direction.
 
     Args:
-        img (numpy.ndarray): An array that gets flipped. This is in
+        img (~numpy.ndarray): An array that gets flipped. This is in
             CHW format.
         random_h (bool): randomly flip in horizontal direction.
         random_v (bool): randomly flip in vertical direction.

--- a/chainercv/transforms/image/random_rotate.py
+++ b/chainercv/transforms/image/random_rotate.py
@@ -5,7 +5,7 @@ def random_rotate(img, return_rotation=False):
     """Randomly rotate images by 90, 180, 270 or 360 degrees.
 
     Args:
-        img (numpy.ndarray): An arrays that get flipped. This is in
+        img (~numpy.ndarray): An arrays that get flipped. This is in
             CHW format.
         return_rotation (bool): returns information of rotation.
 

--- a/chainercv/transforms/image/scale.py
+++ b/chainercv/transforms/image/scale.py
@@ -9,7 +9,7 @@ def scale(img, size):
     Similar resizing will be done otherwise.
 
     Args:
-        img (numpy.ndarray): An image array to be scaled. This is in
+        img (~numpy.ndarray): An image array to be scaled. This is in
             CHW format.
         size (int): the length of the smaller edge.
 

--- a/chainercv/transforms/image/ten_crop.py
+++ b/chainercv/transforms/image/ten_crop.py
@@ -22,7 +22,7 @@ def ten_crop(img, output_shape):
     * bottom-right crop (flipped horizontally)
 
     Args:
-        img (numpy.ndarray): An image array to be cropped. This is in
+        img (~numpy.ndarray): An image array to be cropped. This is in
             CHW format.
         output_shape (tuple): the size of output images after cropping.
             This value is :math:`(heihgt, width)`.


### PR DESCRIPTION
In the document, the format of `numpy.ndarray` is inconsistent.