### PR TITLE
Support grayscale image in resize

### DIFF
--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -18,7 +18,7 @@ except ImportError:
 
     def _resize(img, size):
         channels = []
-        for i in range(3):
+        for i in range(img.shape[2]):
             ch = PIL.Image.fromarray(img[:, :, i], mode='F')
             ch = ch.resize(size, resample=PIL.Image.BILINEAR)
             channels.append(numpy.array(ch))

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -1,13 +1,17 @@
+import numpy
 import warnings
 
 try:
     import cv2
 
     def _resize(img, size):
-        return cv2.resize(img, dsize=size)
+        img = cv2.resize(img, dsize=size)
+        if len(img.shape) == 3:
+            return img
+        else:
+            return img[:, :, numpy.newaxis]
 
 except ImportError:
-    import numpy
     import PIL
 
     warnings.warn(

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -6,10 +6,12 @@ try:
 
     def _resize(img, size):
         img = cv2.resize(img, dsize=size)
-        if len(img.shape) == 3:
-            return img
-        else:
+
+        # If img is grayscale image, cv2 returns two dimentional array.
+        if len(img.shape) == 2:
             return img[:, :, numpy.newaxis]
+        else:
+            return img
 
 except ImportError:
     import PIL

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -7,7 +7,7 @@ try:
     def _resize(img, size):
         img = cv2.resize(img, dsize=size)
 
-        # If img is grayscale image, cv2 returns two dimentional array.
+        # If input is a grayscale image, cv2 returns a two-dimentional array.
         if len(img.shape) == 2:
             return img[:, :, numpy.newaxis]
         else:

--- a/tests/transforms_tests/image_tests/test_resize.py
+++ b/tests/transforms_tests/image_tests/test_resize.py
@@ -8,12 +8,15 @@ from chainercv.transforms import resize
 
 class TestResize(unittest.TestCase):
 
-    def test_resize(self):
+    def test_resize_color(self):
         img = np.random.uniform(size=(3, 24, 32))
-
         out = resize(img, output_shape=(32, 64))
-
         self.assertEqual(out.shape, (3, 32, 64))
+
+    def test_resize_grayscale(self):
+        img = np.random.uniform(size=(1, 24, 32))
+        out = resize(img, output_shape=(32, 64))
+        self.assertEqual(out.shape, (1, 32, 64))
 
 
 testing.run_module(__name__, __file__)


### PR DESCRIPTION
`resize` function  with the `Pillow` backend can not treat grayscale image.
I add a test and fix this bug.