### PR TITLE
Ahange name of args for image shape to 'size'

### DIFF
--- a/chainercv/transforms/bbox/flip_bbox.py
+++ b/chainercv/transforms/bbox/flip_bbox.py
@@ -1,4 +1,4 @@
-def flip_bbox(bbox, img_shape, x_flip=False, y_flip=False):
+def flip_bbox(bbox, size, x_flip=False, y_flip=False):
     """Flip bounding boxes accordingly.
 
     The bounding boxes are expected to be packed into a two dimensional
@@ -11,7 +11,7 @@ def flip_bbox(bbox, img_shape, x_flip=False, y_flip=False):
     Args:
         bbox (~numpy.ndarray): shape is :math:`(R, 4)`. :math:`R` is
             the number of bounding boxes.
-        img_shape (tuple): A tuple of length 2. The height and the width
+        size (tuple): A tuple of length 2. The height and the width
             of the image before resized.
         x_flip (bool): Flip bounding box according to a horizontal flip of
             an image.
@@ -23,7 +23,7 @@ def flip_bbox(bbox, img_shape, x_flip=False, y_flip=False):
         Bounding boxes flipped according to the given flips.
 
     """
-    H, W = img_shape
+    H, W = size
     bbox = bbox.copy()
     if x_flip:
         x_max = W - 1 - bbox[:, 0]

--- a/chainercv/transforms/bbox/resize_bbox.py
+++ b/chainercv/transforms/bbox/resize_bbox.py
@@ -1,4 +1,4 @@
-def resize_bbox(bbox, input_shape, output_shape):
+def resize_bbox(bbox, in_size, out_size):
     """Resize bounding boxes according to image resize.
 
     The bounding boxes are expected to be packed into a two dimensional
@@ -11,9 +11,9 @@ def resize_bbox(bbox, input_shape, output_shape):
     Args:
         bbox (~numpy.ndarray): shape is :math:`(R, 4)`. :math:`R` is
             the number of bounding boxes.
-        input_shape (tuple): A tuple of length 2. The width and the height
+        in_size (tuple): A tuple of length 2. The width and the height
             of the image before resized.
-        output_shape (tuple): A tuple of length 2. The width and the height
+        out_size (tuple): A tuple of length 2. The width and the height
             of the image after resized.
 
     Returns:
@@ -22,8 +22,8 @@ def resize_bbox(bbox, input_shape, output_shape):
 
     """
     bbox = bbox.copy()
-    x_scale = float(output_shape[0]) / input_shape[0]
-    y_scale = float(output_shape[1]) / input_shape[1]
+    x_scale = float(out_size[0]) / in_size[0]
+    y_scale = float(out_size[1]) / in_size[1]
     bbox[:, 0] = x_scale * bbox[:, 0]
     bbox[:, 2] = x_scale * bbox[:, 2]
     bbox[:, 1] = y_scale * bbox[:, 1]

--- a/chainercv/transforms/image/center_crop.py
+++ b/chainercv/transforms/image/center_crop.py
@@ -1,13 +1,13 @@
-def center_crop(img, output_shape, return_slices=False, copy=False):
-    """Center crop an image by `output_shape`.
+def center_crop(img, size, return_slices=False, copy=False):
+    """Center crop an image by `size`.
 
-    An image is cropped to :obj:`output_shape`. The center of the output image
+    An image is cropped to :obj:`size`. The center of the output image
     and the center of the input image are same.
 
     Args:
         img (~numpy.ndarray): An image array to be cropped. This is in
             CHW format.
-        output_shape (tuple): the size of output image after cropping.
+        size (tuple): the size of output image after cropping.
             This value is :math:`(width, height)`.
         return_slices (bool): If :obj:`True`, this function returns information
             of slices.
@@ -28,9 +28,9 @@ def center_crop(img, output_shape, return_slices=False, copy=False):
 
     """
     _, H, W = img.shape
-    oW, oH = output_shape
+    oW, oH = size
     if oW > W or oH > H:
-        raise ValueError('shape of image needs to be larger than output_shape')
+        raise ValueError('shape of image needs to be larger than size')
 
     x_offset = int(round((W - oW) / 2.))
     y_offset = int(round((H - oH) / 2.))

--- a/chainercv/transforms/image/pad.py
+++ b/chainercv/transforms/image/pad.py
@@ -1,52 +1,52 @@
 import numpy as np
 
 
-def pad(img, max_size, bg_value):
+def pad(img, size, bg_value):
     """Pad image to match given size.
 
     Args:
         img (~numpy.ndarray): An array to be transformed. This is in
             CHW format.
-        max_size (tuple of two ints): the size of output image after
-            padding (max_W, max_H).
+        size (tuple of two ints): a tuple of two elements:
+            :obj:`width, height`. The size of the image after padding.
         bg_value (scalar): value of the padded regions
 
     Returns:
         ~numpy.ndarray: a padded array in CHW format.
 
     """
-    x_slices, y_slices = _get_pad_slices(img, max_size=max_size)
-    out = bg_value * np.ones((img.shape[0],) + max_size, dtype=img.dtype)
+    x_slices, y_slices = _get_pad_slices(img, size=size)
+    out = bg_value * np.ones((img.shape[0],) + size, dtype=img.dtype)
     out[:, y_slices, x_slices] = img
     return out
 
 
-def _get_pad_slices(img, max_size):
+def _get_pad_slices(img, size):
     """Get slices needed for padding.
 
     Args:
         img (~numpy.ndarray): this image is in format CHW.
-        max_size (tuple of two ints): (max_W, max_H).
+        size (tuple of two ints): (max_W, max_H).
     """
     _, H, W = img.shape
 
-    if W < max_size[0]:
-        diff_x = max_size[0] - W
+    if W < size[0]:
+        diff_x = size[0] - W
         margin_x = diff_x / 2
         if diff_x % 2 == 0:
-            x_slices = slice(int(margin_x), int(max_size[0] - margin_x))
+            x_slices = slice(int(margin_x), int(size[0] - margin_x))
         else:
-            x_slices = slice(int(margin_x), int(max_size[0] - margin_x - 1))
+            x_slices = slice(int(margin_x), int(size[0] - margin_x - 1))
     else:
-        x_slices = slice(0, int(max_size[0]))
+        x_slices = slice(0, int(size[0]))
 
-    if H < max_size[1]:
-        diff_y = max_size[1] - H
+    if H < size[1]:
+        diff_y = size[1] - H
         margin_y = diff_y / 2
         if diff_y % 2 == 0:
-            y_slices = slice(int(margin_y), int(max_size[1] - margin_y))
+            y_slices = slice(int(margin_y), int(size[1] - margin_y))
         else:
-            y_slices = slice(int(margin_y), int(max_size[1] - margin_y - 1))
+            y_slices = slice(int(margin_y), int(size[1] - margin_y - 1))
     else:
-        y_slices = slice(0, int(max_size[1]))
+        y_slices = slice(0, int(size[1]))
     return x_slices, y_slices

--- a/chainercv/transforms/image/random_crop.py
+++ b/chainercv/transforms/image/random_crop.py
@@ -2,16 +2,16 @@ import random
 import six
 
 
-def random_crop(img, output_shape, return_slices=False, copy=False):
-    """Crop array randomly into `output_shape`.
+def random_crop(img, size, return_slices=False, copy=False):
+    """Crop array randomly into `size`.
 
     The input image is cropped by a randomly selected region whose shape
-    is :obj:`output_shape`.
+    is :obj:`size`.
 
     Args:
         img (~numpy.ndarray): An image array to be cropped. This is in
             CHW format.
-        output_shape (tuple): the size of output image after cropping.
+        size (tuple): the size of output image after cropping.
             This value is :math:`(width, height)`.
         return_slices (bool): If :obj:`True`, this function returns
             information of slices.
@@ -31,7 +31,7 @@ def random_crop(img, output_shape, return_slices=False, copy=False):
             out_img = img[:, y_slice, x_slice]
 
     """
-    W, H = output_shape
+    W, H = size
 
     if img.shape[2] == W:
         x_offset = 0

--- a/chainercv/transforms/image/resize.py
+++ b/chainercv/transforms/image/resize.py
@@ -32,7 +32,7 @@ except ImportError:
         return out
 
 
-def resize(img, output_shape):
+def resize(img, size):
     """Resize image to match the given shape.
 
     A bilinear interpolation is used for resizing.
@@ -50,12 +50,12 @@ def resize(img, output_shape):
     Args:
         img (~numpy.ndarray): An array to be transformed.
             This is in CHW format and the type should be :obj:`numpy.float32`.
-        output_shape (tuple): this is a tuple of length 2. Its elements are
+        size (tuple): this is a tuple of length 2. Its elements are
             ordered as (width, height).
 
     Returns:
         ~numpy.ndarray: A resize array in CHW format.
 
     """
-    img = _resize(img, output_shape)
+    img = _resize(img, size)
     return img

--- a/chainercv/transforms/image/ten_crop.py
+++ b/chainercv/transforms/image/ten_crop.py
@@ -1,11 +1,11 @@
 import numpy as np
 
 
-def ten_crop(img, output_shape):
+def ten_crop(img, size):
     """Crop 10 regions from an array.
 
     This method crops 10 regions. All regions will be in shape
-    :obj:`output_shape`. These regions consist of 1 center crop and 4 corner
+    :obj:`size`. These regions consist of 1 center crop and 4 corner
     crops and horizontal flips of them.
 
     The crops are ordered in this order.
@@ -24,14 +24,14 @@ def ten_crop(img, output_shape):
     Args:
         img (~numpy.ndarray): An image array to be cropped. This is in
             CHW format.
-        output_shape (tuple): the size of output images after cropping.
+        size (tuple): the size of output images after cropping.
             This value is :math:`(width, height)`.
 
     Returns:
         The cropped arrays. The shape of tensor is :math:`(10, C, H, W)`.
 
     """
-    W, H = output_shape
+    W, H = size
     iH, iW = img.shape[1:3]
 
     if iW < W or iH < H:

--- a/chainercv/transforms/keypoint/resize_keypoint.py
+++ b/chainercv/transforms/keypoint/resize_keypoint.py
@@ -1,4 +1,4 @@
-def resize_keypoint(keypoint, input_shape, output_shape):
+def resize_keypoint(keypoint, in_size, out_size):
     """Change values of keypoint according to paramters for resizing an image.
 
     Args:
@@ -7,9 +7,9 @@ def resize_keypoint(keypoint, input_shape, output_shape):
             of keypoint in the image.
             The last dimension is composed of :math:`x` and :math:`y`
             coordinates of the keypoints.
-        input_shape (tuple): A tuple of length 2. The width and the height
+        in_size (tuple): A tuple of length 2. The width and the height
             of the image before resized.
-        output_shape (tuple): A tuple of length 2. The width and the height
+        out_size (tuple): A tuple of length 2. The width and the height
             of the image after resized.
 
     Returns:
@@ -18,8 +18,8 @@ def resize_keypoint(keypoint, input_shape, output_shape):
 
     """
     keypoint = keypoint.copy()
-    x_scale = float(output_shape[0]) / input_shape[0]
-    y_scale = float(output_shape[1]) / input_shape[1]
+    x_scale = float(out_size[0]) / in_size[0]
+    y_scale = float(out_size[1]) / in_size[1]
     keypoint[:, 0] = x_scale * keypoint[:, 0]
     keypoint[:, 1] = y_scale * keypoint[:, 1]
     return keypoint

--- a/examples/semantic_segmentation/fcn/train_fcn.py
+++ b/examples/semantic_segmentation/fcn/train_fcn.py
@@ -58,8 +58,8 @@ def main():
         vgg_subtract_bgr = np.array(
             [103.939, 116.779, 123.68], np.float32)[:, None, None]
         img -= vgg_subtract_bgr
-        img = transforms.pad(img, max_size=(512, 512), bg_value=0)
-        label = transforms.pad(label, max_size=(512, 512), bg_value=-1)
+        img = transforms.pad(img, size=(512, 512), bg_value=0)
+        label = transforms.pad(label, size=(512, 512), bg_value=-1)
         return img, label
 
     train_data = VOCSemanticSegmentationDataset(mode='train')

--- a/tests/transforms_tests/bbox_tests/test_flip_bbox.py
+++ b/tests/transforms_tests/bbox_tests/test_flip_bbox.py
@@ -12,15 +12,13 @@ class TestFlipBbox(unittest.TestCase):
         bbox = np.random.uniform(
             low=0., high=32., size=(10, 4))
 
-        out = flip_bbox(bbox, img_shape=(32, 32),
-                        x_flip=True)
+        out = flip_bbox(bbox, size=(32, 32), x_flip=True)
         bbox_expected = bbox.copy()
         bbox_expected[:, 0] = 31 - bbox[:, 2]
         bbox_expected[:, 2] = 31 - bbox[:, 0]
         np.testing.assert_equal(out, bbox_expected)
 
-        out = flip_bbox(bbox, img_shape=(32, 32),
-                        y_flip=True)
+        out = flip_bbox(bbox, size=(32, 32), y_flip=True)
         bbox_expected = bbox.copy()
         bbox_expected[:, 1] = 31 - bbox[:, 3]
         bbox_expected[:, 3] = 31 - bbox[:, 1]

--- a/tests/transforms_tests/bbox_tests/test_resize_bbox.py
+++ b/tests/transforms_tests/bbox_tests/test_resize_bbox.py
@@ -12,7 +12,7 @@ class TestResizeBbox(unittest.TestCase):
         bbox = np.random.uniform(
             low=0., high=32., size=(10, 4))
 
-        out = resize_bbox(bbox, input_shape=(32, 32), output_shape=(128, 64))
+        out = resize_bbox(bbox, in_size=(32, 32), out_size=(128, 64))
         bbox_expected = bbox.copy()
         bbox_expected[:, 0] = bbox[:, 0] * 4
         bbox_expected[:, 1] = bbox[:, 1] * 2

--- a/tests/transforms_tests/image_tests/test_resize.py
+++ b/tests/transforms_tests/image_tests/test_resize.py
@@ -10,12 +10,12 @@ class TestResize(unittest.TestCase):
 
     def test_resize_color(self):
         img = np.random.uniform(size=(3, 24, 32))
-        out = resize(img, output_shape=(64, 32))
+        out = resize(img, size=(64, 32))
         self.assertEqual(out.shape, (3, 32, 64))
 
     def test_resize_grayscale(self):
         img = np.random.uniform(size=(1, 24, 32))
-        out = resize(img, output_shape=(64, 32))
+        out = resize(img, size=(64, 32))
         self.assertEqual(out.shape, (1, 32, 64))
 
 

--- a/tests/transforms_tests/keypoint_tests/test_resize_keypoint.py
+++ b/tests/transforms_tests/keypoint_tests/test_resize_keypoint.py
@@ -12,9 +12,7 @@ class TestResizeKeypoint(unittest.TestCase):
         keypoint = np.random.uniform(
             low=0., high=32., size=(12, 2))
 
-        out = resize_keypoint(
-            keypoint, input_shape=(32, 32),
-            output_shape=(64, 64))
+        out = resize_keypoint(keypoint, in_size=(32, 32), out_size=(64, 64))
         keypoint[:, :2] *= 2
         np.testing.assert_equal(out, keypoint)
 


### PR DESCRIPTION
`output_shape` was used previously as a name for image shape.
This was used because image shape was in `row, col` order and scikit-image used this naming convention.

Since, image shape is changed to be ordered in `col, row` order, the naming convention should follow those of PIL or OpenCV instead of Scikit-image.
This PR is send to make code follow those conventions.