### PR TITLE
Non maximum suppression

### DIFF
--- a/chainercv/transforms/__init__.py
+++ b/chainercv/transforms/__init__.py
@@ -1,4 +1,5 @@
 from chainercv.transforms.bbox.flip_bbox import flip_bbox  # NOQA
+from chainercv.transforms.bbox.non_maximum_suppression import non_maximum_suppression  # NOQA
 from chainercv.transforms.bbox.resize_bbox import resize_bbox  # NOQA
 from chainercv.transforms.bbox.translate_bbox import translate_bbox  # NOQA
 from chainercv.transforms.image.center_crop import center_crop  # NOQA

--- a/chainercv/transforms/bbox/non_maximum_suppression.py
+++ b/chainercv/transforms/bbox/non_maximum_suppression.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import numpy as np
 
 

--- a/chainercv/transforms/bbox/non_maximum_suppression.py
+++ b/chainercv/transforms/bbox/non_maximum_suppression.py
@@ -5,11 +5,12 @@ import numpy as np
 def non_maximum_suppression(bbox, threshold, limit=None, return_param=False):
     """Suppress bounding boxes according to their Jaccard overlap.
 
-    This method checks each bounding box sequentially and selects the box
-    if the Jaccard overlap between the box and previously selected boxes
-    is less than :obj:`threshold`. This method is mainly used as postprocessing
-    of object detection. In this case, the bounding boxes should be sorted in
-    descending order.
+    This method checks each bounding box sequentially and selects the bounding
+    box if the Jaccard overlap between the bounding box and the previously
+    selected bounding boxes is less than :obj:`threshold`. This method is
+    mainly used as postprocessing of object detection. In this case, the
+    bounding boxes should be sorted by their confidence scores in descending
+    order so that ones with more confidence get prioritized.
 
     The bounding boxes are expected to be packed into a two dimensional
     tensor of shape :math:`(R, 4)`, where :math:`R` is the number of
@@ -19,12 +20,12 @@ def non_maximum_suppression(bbox, threshold, limit=None, return_param=False):
     top right vertices.
 
     Args:
-        bbox (~numpy.ndarray): Bounding boxes to be augmented. The shape is
+        bbox (~numpy.ndarray): Bounding boxes to be transformed. The shape is
             :math:`(R, 4)`. :math:`R` is the number of bounding boxes.
         threshold (float): Thresold of Jaccard overlap.
-        limit (int): the upper bound of the number of selected boxes. If it is
-            not specified, this method selects as many boxes as possible.
-        return_param (bool): returns information of selection.
+        limit (int): The upper bound of the number of the output boxes. If it
+            is not specified, this method selects as many boxes as possible.
+        return_param (bool): Returns information of selection.
 
     Returns:
         ~numpy.ndarray or (~numpy.ndarray, dict):
@@ -32,13 +33,15 @@ def non_maximum_suppression(bbox, threshold, limit=None, return_param=False):
         returns an array :obj:`out_bbox` that is the result of suppression.
 
         If :obj:`return_param = True`,
-        returns a tuple whose elements are :obj:`out_img, param`.
+        returns a tuple whose elements are :obj:`out_bbox, param`.
         :obj:`param` is a dictionary of intermediate parameters whose
         contents are listed below with key, value-type and the description
         of the value.
 
-        * **selection** (:obj:`~numpy.ndarray`): An array which indicates each\
-            bounding box is selected or not.
+        * **selection** (*ndarray*): An array which indicates\
+            whether each bounding box is selected or not.\
+            The shape of this array is :math:`(R,)` and its type is\
+            :obj:`bool`.
 
     """
 

--- a/chainercv/transforms/bbox/non_maximum_suppression.py
+++ b/chainercv/transforms/bbox/non_maximum_suppression.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+
+def non_maximum_suppression(bbox, threshold, limit=None, return_param=False):
+    """Suppress bounding boxes according to their Jaccard overlap.
+
+    This method checks each bounding box sequentially and selects the box
+    if the Jaccard overlap between the box and previously selected boxes
+    is less than :obj:`threshold`. This method is mainly used as postprocessing
+    of object detection. In this case, the bounding boxes should be sorted in
+    descending order.
+
+    The bounding boxes are expected to be packed into a two dimensional
+    tensor of shape :math:`(R, 4)`, where :math:`R` is the number of
+    bounding boxes in the image. The second axis represents attributes of
+    the bounding box. They are :obj:`(x_min, y_min, x_max, y_max)`,
+    where the four attributes are coordinates of the bottom left and the
+    top right vertices.
+
+    Args:
+        bbox (~numpy.ndarray): Bounding boxes to be augmented. The shape is
+            :math:`(R, 4)`. :math:`R` is the number of bounding boxes.
+        threshold (float): Thresold of Jaccard overlap.
+        limit (int): the upper bound of the number of selected boxes. If it is
+            not specified, this method selects as many boxes as possible.
+        return_param (bool): returns information of selection.
+
+    Returns:
+        ~numpy.ndarray or (~numpy.ndarray, dict):
+        If :obj:`return_param = False`,
+        returns an array :obj:`out_bbox` that is the result of suppression.
+
+        If :obj:`return_param = True`,
+        returns a tuple whose elements are :obj:`out_img, param`.
+        :obj:`param` is a dictionary of intermediate parameters whose
+        contents are listed below with key, value-type and the description
+        of the value.
+
+        * **selection** (:obj:`~numpy.ndarray`): An array which indicates each\
+            bounding box is selected or not.
+
+    """
+
+    bbox_area = np.prod(bbox[:, 2:] - bbox[:, :2], axis=1)
+
+    selected = np.zeros(bbox.shape[0], dtype=bool)
+    for i, b in enumerate(bbox):
+        lt = np.maximum(b[:2], bbox[selected, :2])
+        rb = np.minimum(b[2:], bbox[selected, 2:])
+        area = np.prod(rb - lt, axis=1) * (lt < rb).all(axis=1)
+
+        jaccard = area / (bbox_area[i] + bbox_area[selected] - area)
+        if (jaccard >= threshold).any():
+            continue
+
+        selected[i] = True
+        if limit and np.count_nonzero(selected) >= limit:
+            break
+
+    if return_param:
+        return bbox[selected], {'selection': selected}
+    else:
+        return bbox[selected]

--- a/chainercv/transforms/bbox/non_maximum_suppression.py
+++ b/chainercv/transforms/bbox/non_maximum_suppression.py
@@ -23,8 +23,9 @@ def non_maximum_suppression(bbox, threshold, limit=None, return_param=False):
         bbox (~numpy.ndarray): Bounding boxes to be transformed. The shape is
             :math:`(R, 4)`. :math:`R` is the number of bounding boxes.
         threshold (float): Thresold of Jaccard overlap.
-        limit (int): The upper bound of the number of the output boxes. If it
-            is not specified, this method selects as many boxes as possible.
+        limit (int): The upper bound of the number of the output bounding
+            boxes. If it is not specified, this method selects as many
+            bounding boxes as possible.
         return_param (bool): Returns information of selection.
 
     Returns:

--- a/chainercv/transforms/bbox/non_maximum_suppression.py
+++ b/chainercv/transforms/bbox/non_maximum_suppression.py
@@ -44,21 +44,21 @@ def non_maximum_suppression(bbox, threshold, limit=None, return_param=False):
 
     bbox_area = np.prod(bbox[:, 2:] - bbox[:, :2], axis=1)
 
-    selected = np.zeros(bbox.shape[0], dtype=bool)
+    selection = np.zeros(bbox.shape[0], dtype=bool)
     for i, b in enumerate(bbox):
-        lt = np.maximum(b[:2], bbox[selected, :2])
-        rb = np.minimum(b[2:], bbox[selected, 2:])
+        lt = np.maximum(b[:2], bbox[selection, :2])
+        rb = np.minimum(b[2:], bbox[selection, 2:])
         area = np.prod(rb - lt, axis=1) * (lt < rb).all(axis=1)
 
-        jaccard = area / (bbox_area[i] + bbox_area[selected] - area)
+        jaccard = area / (bbox_area[i] + bbox_area[selection] - area)
         if (jaccard >= threshold).any():
             continue
 
-        selected[i] = True
-        if limit and np.count_nonzero(selected) >= limit:
+        selection[i] = True
+        if limit and np.count_nonzero(selection) >= limit:
             break
 
     if return_param:
-        return bbox[selected], {'selection': selected}
+        return bbox[selection], {'selection': selection}
     else:
-        return bbox[selected]
+        return bbox[selection]

--- a/docs/source/reference/transforms.rst
+++ b/docs/source/reference/transforms.rst
@@ -63,6 +63,9 @@ flip_bbox
 ~~~~~~~~~
 .. autofunction:: flip_bbox
 
+non_maximum_suppression
+~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: non_maximum_suppression
 
 resize_bbox
 ~~~~~~~~~~~

--- a/tests/transforms_tests/bbox_tests/test_non_maximum_suppression.py
+++ b/tests/transforms_tests/bbox_tests/test_non_maximum_suppression.py
@@ -9,17 +9,18 @@ from chainercv.transforms import non_maximum_suppression
 @testing.parameterize(
     {'threshold': 1, 'expect': (True, True, True, True)},
     {'threshold': 0.5, 'expect': (True, True, False, True)},
-    {'threshold': 0.3, 'expect': (True, True, False, False)},
-    {'threshold': 0.2, 'expect': (True, False, False, False)},
+    {'threshold': 0.3, 'expect': (True, False, True, True)},
+    {'threshold': 0.2, 'expect': (True, False, False, True)},
+    {'threshold': 0, 'expect': (True, False, False, False)},
 )
 class TestNonMaximumSuppression(unittest.TestCase):
 
     def setUp(self):
         self.bbox = np.array((
-            (1, 2, 3, 4),
-            (0, 1, 4, 5),  # 4/16
-            (1, 2, 3, 5),  # 4/6, 6/16
-            (1, 2, 5, 6),  # 6/16, 9/23, 4/16
+            (0, 0, 4, 4),
+            (1, 1, 5, 5),  # 9/23
+            (2, 1, 6, 5),  # 6/26, 12/20
+            (4, 0, 8, 4),  # 0/32, 3/29, 6/26
         ))
         self.expect = np.array(self.expect)
 

--- a/tests/transforms_tests/bbox_tests/test_non_maximum_suppression.py
+++ b/tests/transforms_tests/bbox_tests/test_non_maximum_suppression.py
@@ -28,10 +28,20 @@ class TestNonMaximumSuppression(unittest.TestCase):
         out = non_maximum_suppression(self.bbox, self.threshold)
         np.testing.assert_equal(out, self.bbox[self.expect])
 
+        out = non_maximum_suppression(self.bbox, self.threshold, limit=2)
+        expect = np.logical_and(self.expect, self.expect.cumsum() <= 2)
+        np.testing.assert_equal(out, self.bbox[expect])
+
     def test_non_maximum_suppression_param(self):
         out, param = non_maximum_suppression(
             self.bbox, self.threshold, return_param=True)
         np.testing.assert_equal(param['selection'], self.expect)
+        np.testing.assert_equal(out, self.bbox[param['selection']])
+
+        out, param = non_maximum_suppression(
+            self.bbox, self.threshold, limit=2, return_param=True)
+        expect = np.logical_and(self.expect, self.expect.cumsum() <= 2)
+        np.testing.assert_equal(param['selection'], expect)
         np.testing.assert_equal(out, self.bbox[param['selection']])
 
 

--- a/tests/transforms_tests/bbox_tests/test_non_maximum_suppression.py
+++ b/tests/transforms_tests/bbox_tests/test_non_maximum_suppression.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy as np
+
+from chainer import testing
+from chainercv.transforms import non_maximum_suppression
+
+
+@testing.parameterize(
+    {'threshold': 1, 'expect': (True, True, True, True)},
+    {'threshold': 0.5, 'expect': (True, True, False, True)},
+    {'threshold': 0.3, 'expect': (True, True, False, False)},
+    {'threshold': 0.2, 'expect': (True, False, False, False)},
+)
+class TestNonMaximumSuppression(unittest.TestCase):
+
+    def setUp(self):
+        self.bbox = np.array((
+            (1, 2, 3, 4),
+            (0, 1, 4, 5),  # 4/16
+            (1, 2, 3, 5),  # 4/6, 6/16
+            (1, 2, 5, 6),  # 6/16, 9/23, 4/16
+        ))
+        self.expect = np.array(self.expect)
+
+    def test_non_maximum_suppression(self):
+        out = non_maximum_suppression(self.bbox, self.threshold)
+        np.testing.assert_equal(out, self.bbox[self.expect])
+
+    def test_non_maximum_suppression_param(self):
+        out, param = non_maximum_suppression(
+            self.bbox, self.threshold, return_param=True)
+        np.testing.assert_equal(param['selection'], self.expect)
+        np.testing.assert_equal(out, self.bbox[param['selection']])
+
+
+testing.run_module(__name__, __file__)


### PR DESCRIPTION
I added `non_maximum_suppression` method.
I think there is room for discussion.

- `non_maximum_suppression` or `suppress_bbox`
Currently, methods related to bbox are named as `<verb>_bbox`. In this manner, the name of this method should be `suppress_bbox`. However the behaviour of this method is well known as `non_maximum_suppression`.
- adding `score` argument or not
Currently, this method do not take `score` argument. It assumes given bbox is sorted in descending order.