### PR TITLE
Fix inconsistency of fill argument

### DIFF
--- a/chainercv/transforms/image/resize_contain.py
+++ b/chainercv/transforms/image/resize_contain.py
@@ -3,7 +3,7 @@ import numpy as np
 from chainercv.transforms import resize
 
 
-def resize_contain(img, size, bg_value=0, return_param=False):
+def resize_contain(img, size, fill=0, return_param=False):
     """Resize the image to fit in the given area while keeping aspect ratio.
 
     If both the width and the height in :obj:`size` are larger than the
@@ -18,7 +18,7 @@ def resize_contain(img, size, bg_value=0, return_param=False):
             CHW format.
         size (tuple of two ints): A tuple of two elements:
             :obj:`width, height`. The size of the image after resizing.
-        bg_value (scalar): Value of the padded regions.
+        fill (float or tuple or ~numpy.ndarray): The value of padded pixels.
         return_param (bool): Returns information of resizing and offsetting.
 
     Returns:
@@ -51,7 +51,8 @@ def resize_contain(img, size, bg_value=0, return_param=False):
     if scale < 1.:
         img = resize(img, scaled_size)
     x_slice, y_slice = _get_pad_slice(img, size=size)
-    out_img = bg_value * np.ones((C, out_H, out_W), dtype=img.dtype)
+    out_img = np.empty((C, out_H, out_W), dtype=img.dtype)
+    out_img[:] = np.array(fill).reshape(-1, 1, 1)
     out_img[:, y_slice, x_slice] = img
 
     if return_param:

--- a/chainercv/transforms/image/resize_contain.py
+++ b/chainercv/transforms/image/resize_contain.py
@@ -18,7 +18,7 @@ def resize_contain(img, size, fill=0, return_param=False):
             CHW format.
         size (tuple of two ints): A tuple of two elements:
             :obj:`width, height`. The size of the image after resizing.
-        fill (float or tuple or ~numpy.ndarray): The value of padded pixels.
+        fill (float, tuple or ~numpy.ndarray): The value of padded pixels.
         return_param (bool): Returns information of resizing and offsetting.
 
     Returns:

--- a/tests/transforms_tests/image_tests/test_resize_contain.py
+++ b/tests/transforms_tests/image_tests/test_resize_contain.py
@@ -6,37 +6,39 @@ from chainer import testing
 from chainercv.transforms import resize_contain
 
 
+@testing.parameterize(
+    {'fill': 128},
+    {'fill': (104, 117, 123)},
+    {'fill':  np.random.uniform(255, size=3)},
+)
 class TestResizeContain(unittest.TestCase):
 
     def test_resize_contain(self):
         img = np.random.uniform(size=(3, 32, 64))
-        bg_value = -1
 
-        out, param = resize_contain(img, (96, 48), bg_value=bg_value,
-                                    return_param=True)
+        out, param = resize_contain(
+            img, (96, 48), fill=self.fill, return_param=True)
 
         np.testing.assert_array_equal(img, out[:, 8:40, 16:80])
-        np.testing.assert_array_equal(bg_value, out[:, 0, 0])
+        np.testing.assert_array_equal(self.fill, out[:, 0, 0])
         self.assertEqual(param['scaled_size'], (64, 32))
         self.assertEqual(param['x_offset'], 16)
         self.assertEqual(param['y_offset'], 8)
 
     def test_resize_contain_canvas_small_x(self):
         img = np.random.uniform(size=(3, 32, 64))
-        bg_value = -1
 
-        out, param = resize_contain(img, (68, 16), bg_value=bg_value,
-                                    return_param=True)
+        out, param = resize_contain(
+            img, (68, 16), fill=self.fill, return_param=True)
         self.assertEqual(param['scaled_size'], (32, 16))
         self.assertEqual(param['x_offset'], 18)
         self.assertEqual(param['y_offset'], 0)
 
     def test_resize_contain_canvas_small_y(self):
         img = np.random.uniform(size=(3, 32, 64))
-        bg_value = -1
 
-        out, param = resize_contain(img, (16, 24), bg_value=bg_value,
-                                    return_param=True)
+        out, param = resize_contain(
+            img, (16, 24), fill=self.fill, return_param=True)
         self.assertEqual(param['scaled_size'], (16, 8))
         self.assertEqual(param['x_offset'], 0)
         self.assertEqual(param['y_offset'], 8)


### PR DESCRIPTION
Both of `resize_contain` and `random_expand` have an argument to specify the value of padded pixels.
However, the designs of this argument are different from each other.

- In `resize_contain`
    - The name is `bg_value`
    - It takes only a scalar value
- In `random_expand`
    - The name is `fill`
    - It takes a scalar, a tuple, or an array

I fitted `resize_contain` to `random_expand`.

This PR is based on #108. I will rebase this PR after #108 is merged.