### PR TITLE
Rename evaluation for semantic segmentation to eval_semantic_segmentation

### DIFF
--- a/chainercv/evaluations/__init__.py
+++ b/chainercv/evaluations/__init__.py
@@ -1,2 +1,2 @@
 from chainercv.evaluations.eval_pck import eval_pck  # NOQA
-from chainercv.evaluations.eval_semantic_segmentation import label_accuracy_score  # NOQA
+from chainercv.evaluations.eval_semantic_segmentation import eval_semantic_segmentation  # NOQA

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -44,27 +44,37 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
     Args:
         label_pred (~numpy.ndarray): An integer array of image containing
             class labels as values, which is obtained from inference.
-            This should be a one channel CHW formatted image.
+            This has shape :math:`(N, 1, H, W)` or :math:`(1, H, W)`,
+            where :math:`N` is size of the batch, :math:`H` is the height
+            and :math:`W` is the width.
         label_true (~numpy.ndarray): An integer array of image containing
             the ground truth class labels as values. A pixel with value
-            "-1" will be ignored during evaluation.
+            "-1" will be ignored during evaluation. Its shape is similar
+            to :obj:`label_pred`.
             Its image size is equal to that of :obj:`label_pred`.
             This should be a one channel CHW formatted image.
         n_class (int): Number of classes.
 
     Returns:
-        (float, float, float, float):
+        (numpy.ndarray, numpy.ndarary, numpy.ndarray, numpy.ndarray):
         A tuple of pixel accuracy, mean pixel accuracy, MIoU and FWIoU.
+        These arrays arrays have shape :math:`(N,)`, where :math:`N` is
+        the number of images in the input.
 
     """
     ndim = label_pred.ndim
     if label_pred.ndim != label_true.ndim:
         raise ValueError(
-            'ground truth and predicted label map should have same number '
-            'of dimensions')
+            'Ground truth and predicted label map should have same number '
+            'of dimensions.')
     if ndim == 3:
         label_pred = label_pred[None]
         label_true = label_true[None]
+    elif ndim < 3:
+        raise ValueError('Input images need to be at least three dimensional.')
+
+    if label_pred.shape[1] != 1 or label_true.shape[1] != 1:
+        raise ValueError('Channel sizes of inputs need to be one.')
 
     N = len(label_pred)
     acc = np.zeros((N,))

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -6,7 +6,7 @@ import six
 from chainer import cuda
 
 
-def _fast_hist(gt_label, pred_label, n_class):
+def _fast_hist(pred_label, gt_label, n_class):
     # Construct histogram for label evaluation.
 
     mask = (gt_label >= 0) & (gt_label < n_class)
@@ -102,7 +102,7 @@ def eval_semantic_segmentation(pred_label, gt_label, n_class):
     fwavacc = np.zeros((N,))
     for i in six.moves.range(len(pred_label)):
         hist = _fast_hist(
-            gt_label[i].flatten(), pred_label[i].flatten(), n_class)
+            pred_label[i].flatten(), gt_label[i].flatten(), n_class)
         acc[i] = np.diag(hist).sum() / hist.sum()
         acc_cls_i = np.diag(hist) / hist.sum(axis=1)
         acc_cls[i] = np.nanmean(acc_cls_i)

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -98,7 +98,7 @@ def eval_semantic_segmentation(pred_label, gt_label, n_class):
     N = len(pred_label)
     acc = np.zeros((N,))
     acc_cls = np.zeros((N,))
-    mean_iu = np.zeros((N,))
+    mean_iou = np.zeros((N,))
     fwavacc = np.zeros((N,))
     for i in six.moves.range(len(pred_label)):
         hist = _fast_hist(
@@ -106,11 +106,11 @@ def eval_semantic_segmentation(pred_label, gt_label, n_class):
         acc[i] = np.diag(hist).sum() / hist.sum()
         acc_cls_i = np.diag(hist) / hist.sum(axis=1)
         acc_cls[i] = np.nanmean(acc_cls_i)
-        iu_denominator = (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
-        iu = np.diag(hist) / iu_denominator
-        mean_iu[i] = np.nanmean(iu)
+        iou_denominator = (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
+        iou = np.diag(hist) / iou_denominator
+        mean_iou[i] = np.nanmean(iou)
         freq = hist.sum(axis=1) / hist.sum()
-        fwavacc[i] = (freq[freq > 0] * iu[freq > 0]).sum()
+        fwavacc[i] = (freq[freq > 0] * iou[freq > 0]).sum()
 
     return (xp.asarray(acc), xp.asarray(acc_cls),
-            xp.asarray(mean_iu), xp.asarray(fwavacc))
+            xp.asarray(mean_iou), xp.asarray(fwavacc))

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -6,18 +6,18 @@ import six
 from chainer import cuda
 
 
-def _fast_hist(label_true, label_pred, n_class):
+def _fast_hist(label_true, pred_label, n_class):
     # Construct histogram for label evaluation.
 
     mask = (label_true >= 0) & (label_true < n_class)
     # an array of shape (n_class, n_class)
     hist = np.bincount(
         n_class * label_true[mask].astype(int) +
-        label_pred[mask], minlength=n_class**2).reshape(n_class, n_class)
+        pred_label[mask], minlength=n_class**2).reshape(n_class, n_class)
     return hist
 
 
-def eval_semantic_segmentation(label_pred, label_true, n_class):
+def eval_semantic_segmentation(pred_label, label_true, n_class):
     """Evaluate results of semantic segmentation.
 
     This function measures four metrics: pixel accuracy,
@@ -53,11 +53,11 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
     A Review on Deep Learning Techniques Applied to Semantic Segmentation. \
     https://arxiv.org/abs/1704.06857
 
-    Types of :obj:`label_pred` and :obj:`label_true` need to be same.
+    Types of :obj:`pred_label` and :obj:`label_true` need to be same.
     The outputs are same type as the inputs.
 
     Args:
-        label_pred (array): An integer array of image containing
+        pred_label (array): An integer array of image containing
             class labels as values, which is obtained from inference.
             This has shape :math:`(N, 1, H, W)` or :math:`(1, H, W)`,
             where :math:`N` is size of the batch, :math:`H` is the height
@@ -65,8 +65,8 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
         label_true (array): An integer array of image containing
             the ground truth class labels as values. A pixel with value
             "-1" will be ignored during evaluation. Its shape is similar
-            to :obj:`label_pred`.
-            Its image size is equal to that of :obj:`label_pred`.
+            to :obj:`pred_label`.
+            Its image size is equal to that of :obj:`pred_label`.
             This should be a one channel CHW formatted image.
         n_class (int): Number of classes.
 
@@ -77,32 +77,32 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
         the number of images in the input.
 
     """
-    xp = cuda.get_array_module(label_pred)
-    label_pred = cuda.to_cpu(label_pred)
+    xp = cuda.get_array_module(pred_label)
+    pred_label = cuda.to_cpu(pred_label)
     label_true = cuda.to_cpu(label_true)
 
-    ndim = label_pred.ndim
-    if label_pred.ndim != label_true.ndim:
+    ndim = pred_label.ndim
+    if pred_label.ndim != label_true.ndim:
         raise ValueError(
             'Ground truth and predicted label map should have same number '
             'of dimensions.')
     if ndim == 3:
-        label_pred = label_pred[None]
+        pred_label = pred_label[None]
         label_true = label_true[None]
     elif ndim < 3:
         raise ValueError('Input images need to be at least three dimensional.')
 
-    if label_pred.shape[1] != 1 or label_true.shape[1] != 1:
+    if pred_label.shape[1] != 1 or label_true.shape[1] != 1:
         raise ValueError('Channel sizes of inputs need to be one.')
 
-    N = len(label_pred)
+    N = len(pred_label)
     acc = np.zeros((N,))
     acc_cls = np.zeros((N,))
     mean_iu = np.zeros((N,))
     fwavacc = np.zeros((N,))
-    for i in six.moves.range(len(label_pred)):
+    for i in six.moves.range(len(pred_label)):
         hist = _fast_hist(
-            label_true[i].flatten(), label_pred[i].flatten(), n_class)
+            label_true[i].flatten(), pred_label[i].flatten(), n_class)
         acc[i] = np.diag(hist).sum() / hist.sum()
         acc_cls_i = np.diag(hist) / hist.sum(axis=1)
         acc_cls[i] = np.nanmean(acc_cls_i)

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -1,5 +1,7 @@
 from __future__ import division
+
 import numpy as np
+import six
 
 
 def _fast_hist(label_true, label_pred, n_class):
@@ -21,25 +23,33 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
     frequency weighted intersection over union.
 
     The definition of these metrics are as follows, where
-    :math:`p_{ij}` is the amount of pixels of class :math:`i`
+    :math:`N_{ij}` is the amount of pixels of class :math:`i`
     inferred to belong to :math:`j` and there is :math:`k` classes.
 
     * Pixel Accuracy (PA)
         :math:`PA = \\frac
-        {\\sum_{i=1}^k p_{ii}}
-        {\\sum_{i=1}^k \\sum_{j=1}^k p_{ij}}`
+        {\\sum_{i=1}^k N_{ii}}
+        {\\sum_{i=1}^k \\sum_{j=1}^k N_{ij}}`
     * Mean Pixel Accuracy (MPA)
         :math:`MPA = \\frac{1}{k}
         \\sum_{i=1}^k
-        \\frac{p_{ii}}{\\sum_{j=1}^k p_{ij}}`
+        \\frac{N_{ii}}{\\sum_{j=1}^k N_{ij}}`
     * Mean Intersection over Union (MIoU)
         :math:`MIoU = \\frac{1}{k}
         \\sum_{i=1}^k
-        \\frac{p_{ii}}{\\sum_{j=1}^k p_{ij} + \\sum_{j=1}^k p_{ji} - p_{ii}}`
+        \\frac{N_{ii}}{\\sum_{j=1}^k N_{ij} + \\sum_{j=1}^k N_{ji} - N_{ii}}`
     * Frequency Weighted Intersection over Union (FWIoU)
-        :math:`FWIoU = \\frac{1}{\\sum_{i=1}^k \\sum_{j=1}^k p_{ij}}
-        \\sum_{i=1}^k \\frac{\\sum_{j=1}^k p_{ij}p_{ii}}
-        {\\sum_{j=1}^k p_{ij} + \\sum_{j=1}^k p_{ji} - p_{ii}}`
+        :math:`FWIoU = \\frac{1}{\\sum_{i=1}^k \\sum_{j=1}^k N_{ij}}
+        \\sum_{i=1}^k \\frac{\\sum_{j=1}^k N_{ij}N_{ii}}
+        {\\sum_{j=1}^k N_{ij} + \\sum_{j=1}^k N_{ji} - N_{ii}}`
+
+    The more detailed descriptions on the above metrics can be found at a
+    review on semantic segmentation[1].
+
+    .. [1] Alberto Garcia-Garcia, Sergio Orts-Escolano, Sergiu Oprea, \
+    Victor Villena-Martinez, Jose Garcia-Rodriguez. \
+    A Review on Deep Learning Techniques Applied to Semantic Segmentation. \
+    https://arxiv.org/abs/1704.06857
 
     Args:
         label_pred (~numpy.ndarray): An integer array of image containing
@@ -56,9 +66,9 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
         n_class (int): Number of classes.
 
     Returns:
-        (numpy.ndarray, numpy.ndarary, numpy.ndarray, numpy.ndarray):
+        (numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray):
         A tuple of pixel accuracy, mean pixel accuracy, MIoU and FWIoU.
-        These arrays arrays have shape :math:`(N,)`, where :math:`N` is
+        These arrays have shape :math:`(N,)`, where :math:`N` is
         the number of images in the input.
 
     """
@@ -81,7 +91,7 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
     acc_cls = np.zeros((N,))
     mean_iu = np.zeros((N,))
     fwavacc = np.zeros((N,))
-    for i in range(len(label_pred)):
+    for i in six.moves.range(len(label_pred)):
         hist = _fast_hist(
             label_true[i].flatten(), label_pred[i].flatten(), n_class)
         acc[i] = np.diag(hist).sum() / hist.sum()

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -104,8 +104,9 @@ def eval_semantic_segmentation(pred_label, gt_label, n_class):
         hist = _fast_hist(
             pred_label[i].flatten(), gt_label[i].flatten(), n_class)
         acc[i] = np.diag(hist).sum() / hist.sum()
-        acc_cls_i = np.diag(hist) / hist.sum(axis=1)
-        acc_cls[i] = np.nanmean(acc_cls_i)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            acc_cls_i = np.diag(hist) / hist.sum(axis=1)
+            acc_cls[i] = np.nanmean(acc_cls_i)
         iou_denominator = (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
         iou = np.diag(hist) / iou_denominator
         mean_iou[i] = np.nanmean(iou)

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -3,31 +3,59 @@ import numpy as np
 
 
 def _fast_hist(label_true, label_pred, n_class):
-    """Construct histogram for label evaluation.
+    # Construct histogram for label evaluation.
 
-    Returns
-        numpy.ndarray of shape (n_class, n_class)
-    """
     mask = (label_true >= 0) & (label_true < n_class)
+    # an array of shape (n_class, n_class)
     hist = np.bincount(
         n_class * label_true[mask].astype(int) +
         label_pred[mask], minlength=n_class**2).reshape(n_class, n_class)
     return hist
 
 
-def label_accuracy_score(label_true, label_pred, n_class):
-    """Returns accuracy score evaluation result.
+def eval_semantic_segmentation(label_pred, label_true, n_class):
+    """Evaluate results of semantic segmentation.
 
-      - overall accuracy
-      - mean accuracy
-      - mean IU
-      - fwavacc
+    This function measures four metrics: pixel accuracy,
+    mean pixel accuracy, mean intersection over union and
+    frequency weighted intersection over union.
+
+    The definition of these metrics are as follows, where
+    :math:`p_{ij}` is the amount of pixels of class :math:`i`
+    inferred to belong to :math:`j` and there is :math:`k` classes.
+
+    * Pixel Accuracy (PA)
+        :math:`PA = \\frac
+        {\\sum_{i=1}^k p_{ii}}
+        {\\sum_{i=1}^k \\sum_{j=1}^k p_{ij}}`
+    * Mean Pixel Accuracy (MPA)
+        :math:`MPA = \\frac{1}{k}
+        \\sum_{i=1}^k
+        \\frac{p_{ii}}{\\sum_{j=1}^k p_{ij}}`
+    * Mean Intersection over Union (MIoU)
+        :math:`MIoU = \\frac{1}{k}
+        \\sum_{i=1}^k
+        \\frac{p_{ii}}{\\sum_{j=1}^k p_{ij} + \\sum_{j=1}^k p_{ji} - p_{ii}}`
+    * Frequency Weighted Intersection over Union (FWIoU)
+        :math:`FWIoU = \\frac{1}{\\sum_{i=1}^k \\sum_{j=1}^k p_{ij}}
+        \\sum_{i=1}^k \\frac{\\sum_{j=1}^k p_{ij}p_{ii}}
+        {\\sum_{j=1}^k p_{ij} + \\sum_{j=1}^k p_{ji} - p_{ii}}`
 
     Args:
-        label_true (~numpy.ndarray): A integer 2D image of classes. A pixel
-            with value "-1" will be ignored during evaluation.
-        label_pred (~numpy.ndarray): A integer 2D image.
+        label_pred (~numpy.ndarray): An integer array of image containing
+            class labels as values, which is obtained from inference.
+            This should be a one channel CHW formatted image.
+        label_true (~numpy.ndarray): An integer array of image containing
+            the ground truth class labels as values. A pixel with value
+            "-1" will be ignored during evaluation.
+            Its image size is equal to that of :obj:`label_pred`.
+            This should be a one channel CHW formatted image.
         n_class (int): Number of classes.
+
+    Returns:
+        (float, float, float, float):
+        A tuple of pixel accuracy, mean pixel accuracy, MIoU and FWIoU.
+
     """
     hist = _fast_hist(label_true.flatten(), label_pred.flatten(), n_class)
     acc = np.diag(hist).sum() / hist.sum()

--- a/chainercv/evaluations/eval_semantic_segmentation.py
+++ b/chainercv/evaluations/eval_semantic_segmentation.py
@@ -82,11 +82,13 @@ def eval_semantic_segmentation(label_pred, label_true, n_class):
     mean_iu = np.zeros((N,))
     fwavacc = np.zeros((N,))
     for i in range(len(label_pred)):
-        hist = _fast_hist(label_true[i].flatten(), label_pred[i].flatten(), n_class)
+        hist = _fast_hist(
+            label_true[i].flatten(), label_pred[i].flatten(), n_class)
         acc[i] = np.diag(hist).sum() / hist.sum()
         acc_cls_i = np.diag(hist) / hist.sum(axis=1)
         acc_cls[i] = np.nanmean(acc_cls_i)
-        iu = np.diag(hist) / (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
+        iu_denominator = (hist.sum(axis=1) + hist.sum(axis=0) - np.diag(hist))
+        iu = np.diag(hist) / iu_denominator
         mean_iu[i] = np.nanmean(iu)
         freq = hist.sum(axis=1) / hist.sum()
         fwavacc[i] = (freq[freq > 0] * iu[freq > 0]).sum()

--- a/docs/source/reference/evaluations.rst
+++ b/docs/source/reference/evaluations.rst
@@ -8,6 +8,6 @@ eval_pck
 ~~~~~~~~
 .. autofunction:: eval_pck
 
-eval_semantic_segmentatioa
+eval_semantic_segmentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autofunction:: eval_semantic_segmentation

--- a/docs/source/reference/evaluations.rst
+++ b/docs/source/reference/evaluations.rst
@@ -8,3 +8,6 @@ eval_pck
 ~~~~~~~~
 .. autofunction:: eval_pck
 
+eval_semantic_segmentatioa
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: eval_semantic_segmentation

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -1,0 +1,23 @@
+import unittest
+
+import numpy as np
+
+from chainercv.evaluations import eval_semantic_segmentation
+
+
+class TestEvalSemanticSegmentation(unittest.TestCase):
+
+    def test_eval_semantic_segmentation(self):
+        predict = np.array([[1, 1, 0], [0, 0, 1]]).reshape(1, 2, 3)
+        gt = np.array([[1, 0, 0], [0, -1, 1]]).reshape(1, 2, 3)
+        # p_00 = 2
+        # p_01 = 1
+        # p_10 = 0
+        # p_11 = 2
+        acc, acc_cls, mean_iu, fwavacc = eval_semantic_segmentation(
+            predict, gt, n_class=2)
+
+        self.assertEqual(acc, 4. / 5.)
+        self.assertEqual(acc_cls, 1. / 2. * (1 + 2. / 3.))
+        self.assertEqual(mean_iu, 1. / 2. * (1. / 3. + 1))
+        self.assertEqual(fwavacc, 1. / 5. * (2. + 4. / 3.))

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -17,7 +17,34 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
         acc, acc_cls, mean_iu, fwavacc = eval_semantic_segmentation(
             predict, gt, n_class=2)
 
-        self.assertEqual(acc, 4. / 5.)
-        self.assertEqual(acc_cls, 1. / 2. * (1 + 2. / 3.))
-        self.assertEqual(mean_iu, 1. / 2. * (1. / 3. + 1))
-        self.assertEqual(fwavacc, 1. / 5. * (2. + 4. / 3.))
+        self.assertTrue(isinstance(acc, np.ndarray))
+        self.assertTrue(isinstance(acc_cls, np.ndarray))
+        self.assertTrue(isinstance(mean_iu, np.ndarray))
+        self.assertTrue(isinstance(fwavacc, np.ndarray))
+        acc_gt = 4. / 5.
+        self.assertEqual(acc[0], 4. / 5.)
+        self.assertEqual(acc_cls[0], 1. / 2. * (1 + 2. / 3.))
+        self.assertEqual(mean_iu[0], 1. / 2. * (1. / 3. + 1))
+        self.assertEqual(fwavacc[0], 1. / 5. * (2. + 4. / 3.))
+
+    def test_eval_semantic_segmentation_batch(self):
+        predict = np.array([[1, 1, 0], [0, 0, 1]]).reshape(1, 2, 3)
+        predict = np.stack((predict, predict))
+        gt = np.array([[1, 0, 0], [0, -1, 1]]).reshape(1, 2, 3)
+        gt = np.stack((gt, gt))
+        # p_00 = 2
+        # p_01 = 1
+        # p_10 = 0
+        # p_11 = 2
+        acc, acc_cls, mean_iu, fwavacc = eval_semantic_segmentation(
+            predict, gt, n_class=2)
+
+        self.assertTrue(isinstance(acc, np.ndarray))
+        self.assertTrue(isinstance(acc_cls, np.ndarray))
+        self.assertTrue(isinstance(mean_iu, np.ndarray))
+        self.assertTrue(isinstance(fwavacc, np.ndarray))
+        for i in range(2):
+            self.assertEqual(acc[i], 4. / 5.)
+            self.assertEqual(acc_cls[i], 1. / 2. * (1 + 2. / 3.))
+            self.assertEqual(mean_iu[i], 1. / 2. * (1. / 3. + 1))
+            self.assertEqual(fwavacc[i], 1. / 5. * (2. + 4. / 3.))

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy as np
 
@@ -31,6 +32,13 @@ from chainercv.evaluations import eval_semantic_segmentation
                  1. / 2. * (1. / 3. + 1.)],
      'fwavacc': [1. / 5. * (2. + 4. / 3.),
                  1. / 5. * (2. + 4. / 3.)]
+     },
+    {'pred_label': [[[0, 0, 0], [0, 0, 0]]],
+     'gt_label': [[[1, 1, 1], [1, 1, 1]]],
+     'acc': [0.],
+     'acc_cls': [0.],
+     'mean_iu': [0.],
+     'fwavacc': [0.]
      }
 )
 class TestEvalSemanticSegmentation(unittest.TestCase):
@@ -39,9 +47,10 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
 
     def check_eval_semantic_segmentation(self, pred_label, gt_label, acc,
                                          acc_cls, mean_iu, fwavacc, n_class):
-        # obtained
-        acc_o, acc_cls_o, mean_iu_o, fwavacc_o = eval_semantic_segmentation(
-            pred_label, gt_label, n_class=n_class)
+        with warnings.catch_warnings(record=True) as w:
+            acc_o, acc_cls_o, mean_iu_o, fwavacc_o =\
+                eval_semantic_segmentation(
+                    pred_label, gt_label, n_class=n_class)
 
         self.assertIsInstance(acc_o, type(acc))
         self.assertIsInstance(acc_cls_o, type(acc_cls))
@@ -52,6 +61,9 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
         np.testing.assert_equal(cuda.to_cpu(acc_cls_o), cuda.to_cpu(acc_cls))
         np.testing.assert_equal(cuda.to_cpu(mean_iu_o), cuda.to_cpu(mean_iu))
         np.testing.assert_equal(cuda.to_cpu(fwavacc_o), cuda.to_cpu(fwavacc))
+
+        # test that no warning has been created
+        self.assertEqual(len(w), 0)
 
     def test_eval_semantic_segmentation_cpu(self):
         self.check_eval_semantic_segmentation(

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -2,48 +2,77 @@ import unittest
 
 import numpy as np
 
+from chainer import cuda
+from chainer import testing
+from chainer.testing import attr
+
+
 from chainercv.evaluations import eval_semantic_segmentation
 
 
+@testing.parameterize(
+    # p_00 = 2
+    # p_01 = 1
+    # p_10 = 0
+    # p_11 = 2
+    {'predict': [[[1, 1, 0], [0, 0, 1]]],
+     'gt': [[[1, 0, 0], [0, -1, 1]]],
+     'acc': [4. / 5.],
+     'acc_cls': [1. / 2. * (1. + 2. / 3.)],
+     'mean_iu': [1. / 2. * (1. / 3. + 1.)],
+     'fwavacc': [1. / 5. * (2. + 4. / 3.)]
+     },
+    {'predict': np.repeat([[[[1, 1, 0], [0, 0, 1]]]], 2, axis=0),
+     'gt': np.repeat([[[[1, 0, 0], [0, -1, 1]]]], 2, axis=0),
+     'acc': [4. / 5., 4. / 5.],
+     'acc_cls': [1. / 2. * (1. + 2. / 3.),
+                 1. / 2. * (1. + 2. / 3.)],
+     'mean_iu': [1. / 2. * (1. / 3. + 1.),
+                 1. / 2. * (1. / 3. + 1.)],
+     'fwavacc': [1. / 5. * (2. + 4. / 3.),
+                 1. / 5. * (2. + 4. / 3.)]
+     }
+)
 class TestEvalSemanticSegmentation(unittest.TestCase):
 
-    def test_eval_semantic_segmentation(self):
-        predict = np.array([[1, 1, 0], [0, 0, 1]]).reshape(1, 2, 3)
-        gt = np.array([[1, 0, 0], [0, -1, 1]]).reshape(1, 2, 3)
-        # p_00 = 2
-        # p_01 = 1
-        # p_10 = 0
-        # p_11 = 2
-        acc, acc_cls, mean_iu, fwavacc = eval_semantic_segmentation(
-            predict, gt, n_class=2)
+    n_class = 2
 
-        self.assertTrue(isinstance(acc, np.ndarray))
-        self.assertTrue(isinstance(acc_cls, np.ndarray))
-        self.assertTrue(isinstance(mean_iu, np.ndarray))
-        self.assertTrue(isinstance(fwavacc, np.ndarray))
-        self.assertEqual(acc[0], 4. / 5.)
-        self.assertEqual(acc_cls[0], 1. / 2. * (1 + 2. / 3.))
-        self.assertEqual(mean_iu[0], 1. / 2. * (1. / 3. + 1))
-        self.assertEqual(fwavacc[0], 1. / 5. * (2. + 4. / 3.))
+    def check_eval_semantic_segmentation(self, predict, gt, acc,
+                                         acc_cls, mean_iu, fwavacc, n_class):
+        # obtained
+        acc_o, acc_cls_o, mean_iu_o, fwavacc_o = eval_semantic_segmentation(
+            predict, gt, n_class=n_class)
 
-    def test_eval_semantic_segmentation_batch(self):
-        predict = np.array([[1, 1, 0], [0, 0, 1]]).reshape(1, 2, 3)
-        predict = np.stack((predict, predict))
-        gt = np.array([[1, 0, 0], [0, -1, 1]]).reshape(1, 2, 3)
-        gt = np.stack((gt, gt))
-        # p_00 = 2
-        # p_01 = 1
-        # p_10 = 0
-        # p_11 = 2
-        acc, acc_cls, mean_iu, fwavacc = eval_semantic_segmentation(
-            predict, gt, n_class=2)
+        self.assertIsInstance(acc_o, type(acc))
+        self.assertIsInstance(acc_cls_o, type(acc_cls))
+        self.assertIsInstance(mean_iu_o, type(mean_iu))
+        self.assertIsInstance(fwavacc_o, type(fwavacc))
 
-        self.assertTrue(isinstance(acc, np.ndarray))
-        self.assertTrue(isinstance(acc_cls, np.ndarray))
-        self.assertTrue(isinstance(mean_iu, np.ndarray))
-        self.assertTrue(isinstance(fwavacc, np.ndarray))
-        for i in range(2):
-            self.assertEqual(acc[i], 4. / 5.)
-            self.assertEqual(acc_cls[i], 1. / 2. * (1 + 2. / 3.))
-            self.assertEqual(mean_iu[i], 1. / 2. * (1. / 3. + 1))
-            self.assertEqual(fwavacc[i], 1. / 5. * (2. + 4. / 3.))
+        np.testing.assert_equal(cuda.to_cpu(acc_o), cuda.to_cpu(acc))
+        np.testing.assert_equal(cuda.to_cpu(acc_cls_o), cuda.to_cpu(acc_cls))
+        np.testing.assert_equal(cuda.to_cpu(mean_iu_o), cuda.to_cpu(mean_iu))
+        np.testing.assert_equal(cuda.to_cpu(fwavacc_o), cuda.to_cpu(fwavacc))
+
+    def test_eval_semantic_segmentation_cpu(self):
+        self.check_eval_semantic_segmentation(
+            np.array(self.predict),
+            np.array(self.gt),
+            np.array(self.acc),
+            np.array(self.acc_cls),
+            np.array(self.mean_iu),
+            np.array(self.fwavacc),
+            self.n_class)
+
+    @attr.gpu
+    def test_eval_semantic_segmentation_gpu(self):
+        self.check_eval_semantic_segmentation(
+            cuda.cupy.array(self.predict),
+            cuda.cupy.array(self.gt),
+            cuda.cupy.array(self.acc),
+            cuda.cupy.array(self.acc_cls),
+            cuda.cupy.array(self.mean_iu),
+            cuda.cupy.array(self.fwavacc),
+            self.n_class)
+
+
+testing.run_module(__name__, __file__)

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -15,15 +15,15 @@ from chainercv.evaluations import eval_semantic_segmentation
     # p_01 = 1
     # p_10 = 0
     # p_11 = 2
-    {'predict': [[[1, 1, 0], [0, 0, 1]]],
-     'gt': [[[1, 0, 0], [0, -1, 1]]],
+    {'pred_label': [[[1, 1, 0], [0, 0, 1]]],
+     'gt_label': [[[1, 0, 0], [0, -1, 1]]],
      'acc': [4. / 5.],
      'acc_cls': [1. / 2. * (1. + 2. / 3.)],
      'mean_iu': [1. / 2. * (1. / 3. + 1.)],
      'fwavacc': [1. / 5. * (2. + 4. / 3.)]
      },
-    {'predict': np.repeat([[[[1, 1, 0], [0, 0, 1]]]], 2, axis=0),
-     'gt': np.repeat([[[[1, 0, 0], [0, -1, 1]]]], 2, axis=0),
+    {'pred_label': np.repeat([[[[1, 1, 0], [0, 0, 1]]]], 2, axis=0),
+     'gt_label': np.repeat([[[[1, 0, 0], [0, -1, 1]]]], 2, axis=0),
      'acc': [4. / 5., 4. / 5.],
      'acc_cls': [1. / 2. * (1. + 2. / 3.),
                  1. / 2. * (1. + 2. / 3.)],
@@ -37,11 +37,11 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
 
     n_class = 2
 
-    def check_eval_semantic_segmentation(self, predict, gt, acc,
+    def check_eval_semantic_segmentation(self, pred_label, gt_label, acc,
                                          acc_cls, mean_iu, fwavacc, n_class):
         # obtained
         acc_o, acc_cls_o, mean_iu_o, fwavacc_o = eval_semantic_segmentation(
-            predict, gt, n_class=n_class)
+            pred_label, gt_label, n_class=n_class)
 
         self.assertIsInstance(acc_o, type(acc))
         self.assertIsInstance(acc_cls_o, type(acc_cls))
@@ -55,8 +55,8 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
 
     def test_eval_semantic_segmentation_cpu(self):
         self.check_eval_semantic_segmentation(
-            np.array(self.predict),
-            np.array(self.gt),
+            np.array(self.pred_label),
+            np.array(self.gt_label),
             np.array(self.acc),
             np.array(self.acc_cls),
             np.array(self.mean_iu),
@@ -66,8 +66,8 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
     @attr.gpu
     def test_eval_semantic_segmentation_gpu(self):
         self.check_eval_semantic_segmentation(
-            cuda.cupy.array(self.predict),
-            cuda.cupy.array(self.gt),
+            cuda.cupy.array(self.pred_label),
+            cuda.cupy.array(self.gt_label),
             cuda.cupy.array(self.acc),
             cuda.cupy.array(self.acc_cls),
             cuda.cupy.array(self.mean_iu),

--- a/tests/evaluations_tests/test_eval_semantic_segmentation.py
+++ b/tests/evaluations_tests/test_eval_semantic_segmentation.py
@@ -21,7 +21,6 @@ class TestEvalSemanticSegmentation(unittest.TestCase):
         self.assertTrue(isinstance(acc_cls, np.ndarray))
         self.assertTrue(isinstance(mean_iu, np.ndarray))
         self.assertTrue(isinstance(fwavacc, np.ndarray))
-        acc_gt = 4. / 5.
         self.assertEqual(acc[0], 4. / 5.)
         self.assertEqual(acc_cls[0], 1. / 2. * (1 + 2. / 3.))
         self.assertEqual(mean_iu[0], 1. / 2. * (1. / 3. + 1))


### PR DESCRIPTION
Merge after #129.

This PR changes name of evaluation code for semantic segmentation to `eval_semantic_segmentation`, which is consistent with #130.

I also added a doc to the function, which looks like below.

Also, its interface is made consistent with other eval functions, and batch images are additionally supported.

![screenshot from 2017-04-27 17 39 29](https://cloud.githubusercontent.com/assets/2062128/25475061/7eec740a-2b70-11e7-8aa5-2de83f6e0ce3.png)

