### PR TITLE
Add speed of Faster RCNN to README

### DIFF
--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -7,6 +7,20 @@
 | VOC 2007 trainval | VOC 2007 test|  69.9 mAP [1] | 70.5 mAP |
 
 
+### Speed
+
+Speed of the Caffe implementation and ChainerCV implementation are almost same in the test mode.
+We compared the time it takes to forward an image.
+
+We compared `chainercv.links.FasterRCNN.__call__` and [Caffe's equivalent function](https://github.com/rbgirshick/py-faster-rcnn/blob/master/lib/fast_rcnn/test.py#L154).
+We used [an image](https://github.com/rbgirshick/py-faster-rcnn/blob/master/data/demo/000456.jpg) from PASCAL VOC 2007 test split.
+Our experiment was conducted on Ubuntu 14.04.5 with Pascal Titan X.
+
+| Reference Implementation | ChainerCV |
+|:-:|:-:|
+|  15.9 img/s | 16.2 img/s |
+
+
 ### Demo
 
 ```

--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -9,16 +9,16 @@
 
 ### Speed
 
-Speed of the Caffe implementation and ChainerCV implementation are almost same in the test mode.
+ChainerCV and Caffe (py-faster-rcnn) implementations run at almost the same speed.
 We compared the time it takes to forward an image.
 
 We compared `chainercv.links.FasterRCNN.__call__` and [Caffe's equivalent function](https://github.com/rbgirshick/py-faster-rcnn/blob/master/lib/fast_rcnn/test.py#L154).
 We used [an image](https://github.com/rbgirshick/py-faster-rcnn/blob/master/data/demo/000456.jpg) from PASCAL VOC 2007 test split.
 Our experiment was conducted on Ubuntu 14.04.5 with Pascal Titan X.
 
-| py-faster-rcnn | ChainerCV |
+| Reference | ChainerCV |
 |:-:|:-:|
-|  15.9 img/s | 16.2 img/s |
+|  15.9 FPS | 16.2 FPS |
 
 
 ### Demo

--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -2,7 +2,7 @@
 
 ### Performance
 
-| Training Setting | Evaluation | Reference Implementation | ChainerCV |
+| Training Setting | Evaluation | Reference | ChainerCV |
 |:-:|:-:|:-:|:-:|
 | VOC 2007 trainval | VOC 2007 test|  69.9 mAP [1] | 70.5 mAP |
 
@@ -16,7 +16,7 @@ We compared `chainercv.links.FasterRCNN.__call__` and [Caffe's equivalent functi
 We used [an image](https://github.com/rbgirshick/py-faster-rcnn/blob/master/data/demo/000456.jpg) from PASCAL VOC 2007 test split.
 Our experiment was conducted on Ubuntu 14.04.5 with Pascal Titan X.
 
-| Reference Implementation | ChainerCV |
+| py-faster-rcnn | ChainerCV |
 |:-:|:-:|
 |  15.9 img/s | 16.2 img/s |
 


### PR DESCRIPTION
Code to benchmark ChainerCV

```python
from chainercv.links import FasterRCNNVGG16
import cupy
import chainer
import time
from chainercv.utils import read_image


img = read_image('data/demo/000456.jpg')

model = FasterRCNNVGG16(pretrained_model='voc07')
model.to_gpu()

_, H, W = img.shape

img_cpu = model.prepare(img)
_, o_H, o_W = img_cpu.shape
scale = float(o_H) / H


for i in range(5):
    img = chainer.Variable(img_cpu[None], volatile=chainer.flag.ON)
    img.to_gpu()
    start = time.time()
    out = model(img, scale)
    out[0].to_cpu()
    print time.time() - start


print(1./ 0.0629138946533 ) # time of Caffe
print(1. / 0.0617141723633)  # time of ChainerCV

```