### PR TITLE
Change README for SegNet

### DIFF
--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -87,5 +87,5 @@ The above values of the official implementation is found here: [Getting Started 
 
 # Reference
 
-- Vijay Badrinarayanan, Alex Kendall and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Image Segmentation." PAMI, 2017. 
-- Vijay Badrinarayanan, Ankur Handa and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Robust Semantic Pixel-Wise Labelling." arXiv preprint arXiv:1505.07293, 2015.
+1. Vijay Badrinarayanan, Alex Kendall and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Image Segmentation." PAMI, 2017. 
+2. Vijay Badrinarayanan, Ankur Handa and Roberto Cipolla "SegNet: A Deep Convolutional Encoder-Decoder Architecture for Robust Semantic Pixel-Wise Labelling." arXiv preprint arXiv:1505.07293, 2015.

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -14,7 +14,7 @@ python calc_weight.py
 First, move to this directory (i.e., `examples/segnet`) and run:
 
 ```
-CHAINER_SEED=2017 CHAINER_TYPE_CHECK=0 python -OO -W ignore train.py --gpu 0
+python train.py --gpu 0
 ```
 
 ## NOTE

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -14,7 +14,7 @@ python calc_weight.py
 First, move to this directory (i.e., `examples/segnet`) and run:
 
 ```
-python train.py --gpu 0
+python train.py [--gpu <gpu>]
 ```
 
 ## NOTE


### PR DESCRIPTION
I found that options included in the current README are not necessary.
Without the options, I obtained similar results.

Also, the results are not reproducible by setting CHAINER_SEED in the current implementation.

```
                    Sky : 0.8657
               Building : 0.6724
                   Pole : 0.1778
                   Road : 0.8200
               Pavement : 0.5110
                   Tree : 0.6099
             SignSymbol : 0.1773
                  Fence : 0.1538
                    Car : 0.5875
             Pedestrian : 0.2771
              Bicyclist : 0.2387
=================================
               mean IoU : 0.4628
 Class average accuracy : 0.6299
Global average accuracy : 0.8262

```