### PR TITLE
Fix case of package names

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,10 @@ channels:
 - !!python/unicode
   'defaults'
 dependencies:
-  - cython
+  - Cython
   - opencv3=3.2.0
   - matplotlib
   - numpy
-  - pillow
+  - Pillow
   - pip:
     - chainer=1.24

--- a/environment_minimum.yml
+++ b/environment_minimum.yml
@@ -3,8 +3,8 @@ channels:
 - !!python/unicode
   'defaults'
 dependencies:
-  - cython
+  - Cython
   - numpy
-  - pillow
+  - Pillow
   - pip:
     - chainer=1.24

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ cmdclass = {'build_ext': build_ext}
 
 install_requires = [
     'chainer==1.24',
-    'cython',
-    'pillow'
+    'Cython',
+    'Pillow'
 ]
 
 setup(


### PR DESCRIPTION
`Cython` and `Pillow` start with  a capital letter in PyPi.
https://pypi.python.org/pypi/Cython/0.25.2
https://pypi.python.org/pypi/Pillow/4.1.1