### PR TITLE
Accept pretrained_model path for demos

### DIFF
--- a/examples/faster_rcnn/README.md
+++ b/examples/faster_rcnn/README.md
@@ -23,8 +23,10 @@ Our experiment was conducted on Ubuntu 14.04.5 with Pascal Titan X.
 
 ### Demo
 
+If a path to pretrained model path is not given, weights distributed on the internet will be used.
+
 ```
-$ python demo.py [--gpu <gpu>] <image>.jpg
+$ python demo.py [--gpu <gpu>] [--pretrained_model <model_path>] <image>.jpg
 ```
 
 This example will automatically download a pretrained weights from the internet when executed.

--- a/examples/faster_rcnn/demo.py
+++ b/examples/faster_rcnn/demo.py
@@ -12,10 +12,13 @@ from chainercv.visualizations import vis_bbox
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--gpu', type=int, default=-1)
+    parser.add_argument('--pretrained_model', default='voc07')
     parser.add_argument('image')
     args = parser.parse_args()
 
-    model = FasterRCNNVGG16(pretrained_model='voc07')
+    model = FasterRCNNVGG16(
+        n_fg_class=len(voc_detection_label_names),
+        pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
         model.to_gpu(args.gpu)

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -40,6 +40,12 @@ wget https://raw.githubusercontent.com/alexgkendall/SegNet-Tutorial/master/CamVi
 python demo.py 0001TP_008550.png
 ```
 
+`demo.py` has the following commandline interface.
+
+```
+python demo.py [--gpu <gpu>] [--pretrained_model <model_path>] <image>.jpg
+```
+
 # Evaluation
 
 The trained weights to replicate the same results as below is here: [model_iteration-16000](https://www.dropbox.com/s/exas66necaqbxyw/model_iteration-16000).

--- a/examples/segnet/README.md
+++ b/examples/segnet/README.md
@@ -37,14 +37,9 @@ Here is a quick demo using our pretrained weights. The pretrained model is autom
 
 ```
 wget https://raw.githubusercontent.com/alexgkendall/SegNet-Tutorial/master/CamVid/test/0001TP_008550.png
-python demo.py 0001TP_008550.png
+python demo.py [--gpu <gpu>] [--pretrained_model <model_path>] 0001TP_008550.png
 ```
 
-`demo.py` has the following commandline interface.
-
-```
-python demo.py [--gpu <gpu>] [--pretrained_model <model_path>] <image>.jpg
-```
 
 # Evaluation
 

--- a/examples/segnet/demo.py
+++ b/examples/segnet/demo.py
@@ -14,10 +14,13 @@ from chainercv.visualizations import vis_label
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--gpu', type=int, default=-1)
+    parser.add_argument('--pretrained_model', default='camvid')
     parser.add_argument('image')
     args = parser.parse_args()
 
-    model = SegNetBasic(n_class=11, pretrained_model='camvid')
+    model = SegNetBasic(
+        n_class=len(camvid_label_names),
+        pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
         model.to_gpu(args.gpu)

--- a/examples/ssd/README.md
+++ b/examples/ssd/README.md
@@ -11,9 +11,9 @@ PASCAL VOC2007 Test
 Scores are mean Average Precision (mAP) with PASCAL VOC2007 metric.
 
 ## Demo
-Detect objects in an given image. This demo downloads Pascal VOC pretrained model automatically.
+Detect objects in an given image. This demo downloads Pascal VOC pretrained model automatically if a pretrained model path is not given.
 ```
-$ python demo.py [--model ssd300|ssd512] [--gpu <gpu>] <image>.jpg
+$ python demo.py [--model ssd300|ssd512] [--gpu <gpu>] [--pretrained_model <model_path>] <image>.jpg
 ```
 
 ## Convert Caffe model

--- a/examples/ssd/demo.py
+++ b/examples/ssd/demo.py
@@ -15,13 +15,18 @@ def main():
     parser.add_argument(
         '--model', choices=('ssd300', 'ssd512'), default='ssd300')
     parser.add_argument('--gpu', type=int, default=-1)
+    parser.add_argument('--pretrained_model', default='voc0712')
     parser.add_argument('image')
     args = parser.parse_args()
 
     if args.model == 'ssd300':
-        model = SSD300(pretrained_model='voc0712')
+        model = SSD300(
+            n_fg_class=len(voc_detection_label_names),
+            pretrained_model=args.pretrained_model)
     elif args.model == 'ssd512':
-        model = SSD512(pretrained_model='voc0712')
+        model = SSD512(
+            n_fg_class=len(voc_detection_label_names),
+            pretrained_model=args.pretrained_model)
 
     if args.gpu >= 0:
         chainer.cuda.get_device(args.gpu).use()


### PR DESCRIPTION
It is convenient to have this when a user wants to run a model trained by the train script.